### PR TITLE
Fix links to from TiDB to Snowflake/Redshift type mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ All DDL which will change the schema of table are supported (except index relate
 > **Note**
 > 1. Snowflake does not support partition table, tidb2dw will view table with multiple partitions as ordinary table.
 > 2. Snowflake has a lot of limitations on modifying column type, like Snowflake does not support update column default value, refer to [Snowflake Docs](https://docs.snowflake.com/en/sql-reference/sql/alter-table-column).
-> 3. The type mapping from TiDB to Snowflake is defined [here](./pkg/snowsql/types.go).
+> 3. The type mapping from TiDB to Snowflake is defined [here](https://github.com/pingcap-inc/tidb2dw/blob/main/pkg/snowsql/types.go).
 > 4. Should execute at least one DML before DDL or will report error.
 
 ### Redshift
@@ -89,5 +89,5 @@ All DDL which will change the schema of table are supported (except index relate
 - Truncate table
 
 > **Note**
-> 1. The type mapping from TiDB to Redshift is defined [here](./pkg/redshiftsql/types.go).
+> 1. The type mapping from TiDB to Redshift is defined [here](https://github.com/pingcap-inc/tidb2dw/blob/main/pkg/redshiftsql/types.go).
 > 2. Should execute at least one DML before DDL or will report error.


### PR DESCRIPTION
The current links below say "Not Found"

https://github.com/pingcap-inc/pkg/snowsql/types.go
https://github.com/pingcap-inc/pkg/redshiftsql/types.go