### PR TITLE
feat: handle credentials through storageURI

### DIFF
--- a/cmd/core.go
+++ b/cmd/core.go
@@ -105,7 +105,7 @@ func getS3URIWithCredentials(storagePath string, cred *credentials.Value) (*url.
 		return nil, errors.New("Not a s3 storage")
 	}
 
-	// append credentials file path to query string
+	// append credentials to query string
 	values := url.Values{}
 	values.Add("access-key", cred.AccessKeyID)
 	values.Add("secret-access-key", cred.SecretAccessKey)

--- a/cmd/redshift.go
+++ b/cmd/redshift.go
@@ -61,7 +61,12 @@ func NewRedshiftCmd() *cobra.Command {
 			}
 		}
 
-		snapshotURI, incrementURI, err := genURI(storagePath)
+		storageURI, err := getS3URIWithCredentials(storagePath, credValue)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		snapshotURI, incrementURI, err := genSnapshotAndIncrementURIs(storageURI)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -92,7 +97,7 @@ func NewRedshiftCmd() *cobra.Command {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		return Replicate(&tidbConfigFromCli, tableFQN, storagePath, snapshotConcurrency, cdcHost, cdcPort, cdcFlushInterval, cdcFileSize, *credValue, snapConnector, increConnector, timezone, mode)
+		return Replicate(&tidbConfigFromCli, tableFQN, storageURI, snapshotConcurrency, cdcHost, cdcPort, cdcFlushInterval, cdcFileSize, *credValue, snapConnector, increConnector, timezone, mode)
 	}
 
 	cmd := &cobra.Command{

--- a/cmd/snowflake.go
+++ b/cmd/snowflake.go
@@ -61,7 +61,12 @@ func NewSnowflakeCmd() *cobra.Command {
 			}
 		}
 
-		snapshotURI, incrementURI, err := genURI(storagePath)
+		storageURI, err := getS3URIWithCredentials(storagePath, credValue)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		snapshotURI, incrementURI, err := genSnapshotAndIncrementURIs(storageURI)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -88,7 +93,7 @@ func NewSnowflakeCmd() *cobra.Command {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		return Replicate(&tidbConfigFromCli, tableFQN, storagePath, snapshotConcurrency, cdcHost, cdcPort, cdcFlushInterval, cdcFileSize, *credValue, snapConnector, increConnector, timezone, mode)
+		return Replicate(&tidbConfigFromCli, tableFQN, storageURI, snapshotConcurrency, cdcHost, cdcPort, cdcFlushInterval, cdcFileSize, *credValue, snapConnector, increConnector, timezone, mode)
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/cdc/config.go
+++ b/pkg/cdc/config.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"time"
-
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/pingcap/errors"
 )
 
 type FilterConfig struct {
@@ -45,22 +42,13 @@ type SinkURIConfig struct {
 	flushInterval time.Duration
 	fileSize      int64
 	protocol      string
-	cred          *credentials.Value
 }
 
 func (s *SinkURIConfig) genSinkURI() (*url.URL, error) {
-	if s.storageUri.Scheme != "s3" {
-		return nil, errors.Errorf("Only support s3 storage")
-	}
 	values := s.storageUri.Query()
 	values.Add("flush-interval", s.flushInterval.String())
 	values.Add("file-size", fmt.Sprint(s.fileSize))
 	values.Add("protocol", s.protocol)
-	values.Add("access-key", s.cred.AccessKeyID)
-	values.Add("secret-access-key", s.cred.SecretAccessKey)
-	if s.cred.SessionToken != "" {
-		values.Add("session-token", s.cred.SessionToken)
-	}
 	s.storageUri.RawQuery = values.Encode()
 	return s.storageUri, nil
 }

--- a/pkg/cdc/connector.go
+++ b/pkg/cdc/connector.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/pkg/config"
@@ -25,13 +24,12 @@ type CDCConnector struct {
 	SinkURI       *url.URL
 }
 
-func NewCDCConnector(cdcHost string, cdcPort int, tableFQN string, startTSO uint64, storageUri *url.URL, flushInterval time.Duration, fileSize int64, cred *credentials.Value) (*CDCConnector, error) {
+func NewCDCConnector(cdcHost string, cdcPort int, tableFQN string, startTSO uint64, storageUri *url.URL, flushInterval time.Duration, fileSize int64) (*CDCConnector, error) {
 	sinkURIConfig := &SinkURIConfig{
 		storageUri:    storageUri,
 		flushInterval: flushInterval,
 		fileSize:      fileSize,
 		protocol:      "csv",
-		cred:          cred,
 	}
 	sinkURI, err := sinkURIConfig.genSinkURI()
 	if err != nil {

--- a/pkg/coreinterfaces/connector.go
+++ b/pkg/coreinterfaces/connector.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"net/url"
 
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/pingcap/tiflow/pkg/sink/cloudstorage"
 )
 
@@ -26,7 +25,7 @@ type Connector interface {
 	LoadIncrement(tableDef cloudstorage.TableDefinition, uri *url.URL, filePath string) error
 	// Clone return a new Connector wihch reuses the same connection to the Data Warehouse
 	// FIXME: tables with different schemas/databases should not reuse the same connection
-	Clone(stageName string, storageURI *url.URL, credentials *credentials.Value) (Connector, error)
+	Clone(stageName string, storageURI *url.URL) (Connector, error)
 	// Close closes the connection to the Data Warehouse
 	Close()
 }

--- a/pkg/redshiftsql/connector.go
+++ b/pkg/redshiftsql/connector.go
@@ -145,8 +145,8 @@ func (rc *RedshiftConnector) LoadIncrement(tableDef cloudstorage.TableDefinition
 	return nil
 }
 
-func (rc *RedshiftConnector) Clone(externalTableName string, storageURI *url.URL, s3credentials *credentials.Value) (coreinterfaces.Connector, error) {
-	return NewRedshiftConnector(rc.db, rc.schemaName, externalTableName, rc.iamRole, storageURI, s3credentials)
+func (rc *RedshiftConnector) Clone(externalTableName string, storageURI *url.URL) (coreinterfaces.Connector, error) {
+	return NewRedshiftConnector(rc.db, rc.schemaName, externalTableName, rc.iamRole, storageURI, rc.s3Credentials)
 }
 
 func (rc *RedshiftConnector) Close() {

--- a/pkg/snowsql/connector.go
+++ b/pkg/snowsql/connector.go
@@ -22,6 +22,8 @@ type SnowflakeConnector struct {
 
 	stageName string
 
+	s3Credentials *credentials.Value
+
 	columns []cloudstorage.TableCol
 }
 
@@ -39,9 +41,10 @@ func NewSnowflakeConnector(db *sql.DB, stageName string, storageURI *url.URL, cr
 	}
 
 	return &SnowflakeConnector{
-		db:        db,
-		stageName: stageName,
-		columns:   nil,
+		db:            db,
+		stageName:     stageName,
+		s3Credentials: credentials,
+		columns:       nil,
 	}, nil
 }
 
@@ -139,8 +142,8 @@ func (sc *SnowflakeConnector) LoadIncrement(tableDef cloudstorage.TableDefinitio
 	return nil
 }
 
-func (sc *SnowflakeConnector) Clone(stageName string, storageURI *url.URL, credentials *credentials.Value) (coreinterfaces.Connector, error) {
-	return NewSnowflakeConnector(sc.db, stageName, storageURI, credentials)
+func (sc *SnowflakeConnector) Clone(stageName string, storageURI *url.URL) (coreinterfaces.Connector, error) {
+	return NewSnowflakeConnector(sc.db, stageName, storageURI, sc.s3Credentials)
 }
 
 func (sc *SnowflakeConnector) Close() {


### PR DESCRIPTION
This PR introduces how to handle cloud provider credentials via storageURI. 

Since TiCDC, dumpling, and tidb2dw all use [`br.storage.ParseBackend`](https://github.com/pingcap/tidb/blob/master/br/pkg/storage/parse.go#L46) to build a storage instance, it supports passing a storageURI that carries [credentials](https://docs.pingcap.com/tidb/stable/backup-and-restore-storages#uri-format). By following this approach, we can reduce the amount of credential logic in tidb2dw.