### PR TITLE
fix: display clear error message when user input invalid command of flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,8 +14,8 @@ func init() {
 	rootCmd = &cobra.Command{
 		Use:                "tidb2dw",
 		Short:              "A service to replicate data changes from TiDB to Data Warehouse in real-time",
-		SilenceErrors:      true,
 		DisableFlagParsing: true,
+		SilenceUsage:       true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return cmd.Help()
@@ -27,7 +27,7 @@ func init() {
 				fmt.Println(version.NewTiDB2DWVersion().String())
 				return nil
 			default:
-				return cmd.Help()
+				return fmt.Errorf("unknown flag: %s, run `tidb2dw --help` for usage", args[0])
 			}
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func init() {
 				fmt.Println(version.NewTiDB2DWVersion().String())
 				return nil
 			default:
-				return fmt.Errorf("unknown flag: %s, run `tidb2dw --help` for usage", args[0])
+				return fmt.Errorf("unknown flag: %s\nRun `tidb2dw --help` for usage.", args[0])
 			}
 		},
 	}


### PR DESCRIPTION
Currently, it always displays a usage message when an invalid command or flags are inputted, which can confuse the user.

This PR will provide users with a clearer error message.

```
❯ go run . dw
Error: unknown command "dw" for "tidb2dw"
Run 'tidb2dw --help' for usage.
```

```
❯ go run . -vv
Error: unknown flag: -vv
Run `tidb2dw --help` for usage.
```