### PR TITLE
Fix stage can not be dropped

### DIFF
--- a/cmd/bigquery.go
+++ b/cmd/bigquery.go
@@ -77,7 +77,10 @@ func NewBigQueryCmd() *cobra.Command {
 			if err != nil {
 				return errors.Trace(err)
 			}
-
+			bqClient, err = bigqueryConfigFromCli.NewClient()
+			if err != nil {
+				return errors.Trace(err)
+			}
 			increConnector, err := bigquerysql.NewBigQueryConnector(
 				bqClient,
 				fmt.Sprintf("increment_external_%s", sourceTable),
@@ -90,15 +93,6 @@ func NewBigQueryCmd() *cobra.Command {
 			}
 			increConnectorMap[tableFQN] = increConnector
 		}
-
-		defer func() {
-			for _, connector := range snapConnectorMap {
-				connector.Close()
-			}
-			for _, connector := range increConnectorMap {
-				connector.Close()
-			}
-		}()
 
 		return Replicate(
 			&tidbConfigFromCli, tables, storageURI, snapshotURI, incrementURI, snapshotConcurrency,

--- a/cmd/databricks.go
+++ b/cmd/databricks.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/pingcap-inc/tidb2dw/pkg/databrickssql"
 	"time"
+
+	"github.com/pingcap-inc/tidb2dw/pkg/databrickssql"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/pingcap-inc/tidb2dw/pkg/apiservice"
@@ -88,6 +89,10 @@ func NewDatabricksCmd() *cobra.Command {
 				return errors.Trace(err)
 			}
 			snapConnectorMap[tableFQN] = snapConnector
+			db, err = databricksConfigFromCli.OpenDB()
+			if err != nil {
+				return errors.Trace(err)
+			}
 			increConnector, err := databrickssql.NewDatabricksConnector(
 				db,
 				credential,
@@ -99,14 +104,6 @@ func NewDatabricksCmd() *cobra.Command {
 			increConnectorMap[tableFQN] = increConnector
 		}
 
-		defer func() {
-			for _, connector := range snapConnectorMap {
-				connector.Close()
-			}
-			for _, connector := range increConnectorMap {
-				connector.Close()
-			}
-		}()
 		return Replicate(&tidbConfigFromCli, tables, storageURI, snapshotURI, incrementURI,
 			snapshotConcurrency, cdcHost, cdcPort, cdcFlushInterval, cdcFileSize, snapConnectorMap,
 			increConnectorMap, mode)

--- a/cmd/redshift.go
+++ b/cmd/redshift.go
@@ -92,7 +92,10 @@ func NewRedshiftCmd() *cobra.Command {
 				return errors.Trace(err)
 			}
 			snapConnectorMap[tableFQN] = snapConnector
-
+			db, err = redshiftConfigFromCli.OpenDB()
+			if err != nil {
+				return errors.Trace(err)
+			}
 			increConnector, err := redshiftsql.NewRedshiftConnector(
 				db,
 				redshiftConfigFromCli.Schema,
@@ -106,15 +109,6 @@ func NewRedshiftCmd() *cobra.Command {
 			}
 			increConnectorMap[tableFQN] = increConnector
 		}
-
-		defer func() {
-			for _, connector := range snapConnectorMap {
-				connector.Close()
-			}
-			for _, connector := range increConnectorMap {
-				connector.Close()
-			}
-		}()
 
 		return Replicate(&tidbConfigFromCli, tables, storageURI, snapshotURI, incrementURI,
 			snapshotConcurrency, cdcHost, cdcPort, cdcFlushInterval, cdcFileSize,

--- a/cmd/snowflake.go
+++ b/cmd/snowflake.go
@@ -90,7 +90,10 @@ func NewSnowflakeCmd() *cobra.Command {
 				return errors.Trace(err)
 			}
 			snapConnectorMap[tableFQN] = snapConnector
-
+			db, err = snowflakeConfigFromCli.OpenDB()
+			if err != nil {
+				return errors.Trace(err)
+			}
 			increConnector, err := snowsql.NewSnowflakeConnector(
 				db,
 				fmt.Sprintf("increment_external_%s", sourceTable),
@@ -102,15 +105,6 @@ func NewSnowflakeCmd() *cobra.Command {
 			}
 			increConnectorMap[tableFQN] = increConnector
 		}
-
-		defer func() {
-			for _, connector := range snapConnectorMap {
-				connector.Close()
-			}
-			for _, connector := range increConnectorMap {
-				connector.Close()
-			}
-		}()
 
 		return Replicate(&tidbConfigFromCli, tables, storageURI, snapshotURI, incrementURI,
 			snapshotConcurrency, cdcHost, cdcPort, cdcFlushInterval, cdcFileSize,

--- a/replicate/snapshot.go
+++ b/replicate/snapshot.go
@@ -75,6 +75,9 @@ func (sess *SnapshotReplicateSession) Close() {
 	if sess.TiDBPool != nil {
 		sess.TiDBPool.Close()
 	}
+	if sess.DataWarehousePool != nil {
+		sess.DataWarehousePool.Close()
+	}
 }
 
 func (sess *SnapshotReplicateSession) Run() error {


### PR DESCRIPTION
When we reuse the database connection, incremental stage can not be dropped since connection is closed.