### PR TITLE
gcloud: no need to explicitly define credentials-file-path

### DIFF
--- a/cmd/core.go
+++ b/cmd/core.go
@@ -91,9 +91,11 @@ func getGCSURIWithCredentials(storagePath string, credentialsFilePath string) (*
 	}
 
 	// append credentials file path to query string
-	values := url.Values{}
-	values.Add("credentials-file", credentialsFilePath)
-	uri.RawQuery = values.Encode()
+	if credentialsFilePath != "" {
+		values := url.Values{}
+		values.Add("credentials-file", credentialsFilePath)
+		uri.RawQuery = values.Encode()
+	}
 	return uri, nil
 }
 

--- a/cmd/gcs.go
+++ b/cmd/gcs.go
@@ -83,7 +83,6 @@ func NewGCSCmd() *cobra.Command {
 	cmd.Flags().StringVar(&logLevel, "log.level", "info", "log level")
 
 	cmd.MarkFlagRequired("storage")
-	cmd.MarkFlagRequired("credentials-file-path")
 
 	return cmd
 }

--- a/pkg/bigquerysql/config.go
+++ b/pkg/bigquerysql/config.go
@@ -14,5 +14,9 @@ type BigQueryConfig struct {
 }
 
 func (cfg *BigQueryConfig) NewClient() (*bigquery.Client, error) {
-	return bigquery.NewClient(context.Background(), cfg.ProjectID, option.WithCredentialsFile(cfg.CredentialsFilePath))
+	opts := []option.ClientOption{}
+	if cfg.CredentialsFilePath != "" {
+		opts = append(opts, option.WithCredentialsFile(cfg.CredentialsFilePath))
+	}
+	return bigquery.NewClient(context.Background(), cfg.ProjectID, opts...)
 }

--- a/pkg/bigquerysql/connector.go
+++ b/pkg/bigquerysql/connector.go
@@ -108,7 +108,8 @@ func (bc *BigQueryConnector) CopyTableSchema(sourceDatabase string, sourceTable 
 
 func (bc *BigQueryConnector) LoadSnapshot(targetTable, filePath string) error {
 	// FIXME: if source table is empty, bigquery will fail to load (file not found)
-	err := loadGCSFileToBigQuery(bc.ctx, bc.bqClient, bc.datasetID, bc.tableID, filePath)
+	absolutePath := fmt.Sprintf("%s/%s", bc.storageURL, filePath)
+	err := loadGCSFileToBigQuery(bc.ctx, bc.bqClient, bc.datasetID, bc.tableID, absolutePath)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
This PR let tidb2dw support read google credentials file from default path, no need to explicitly define it in command args.