### PR TITLE
bigquery: does not support sync column default value

### DIFF
--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -24,7 +24,7 @@ To replicate snapshot and incremental data of a TiDB Table to BigQuery:
 
 All DDL which will change the schema of table are supported (except index related), including:
 
-- Add column
+- Add column without default value
 - Drop column
 - Rename column
 - Drop table

--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -34,3 +34,4 @@ All DDL which will change the schema of table are supported (except index relate
 >
 > 1. BigQuery has some limitations on modifying table schemas, like BigQuery does not support add a REQUIRED column to an existing table schema, refer to [BigQuery Docs](https://cloud.google.com/bigquery/docs/managing-table-schemas), in some cases, its better to recreate the table.
 > 2. The type mapping from TiDB to BigQuery is defined [here](https://github.com/pingcap-inc/tidb2dw/blob/main/pkg/bigquerysql/types.go).
+> 3. tidb2dw will not sync column's default value to BigQuery, when you add a new column with default value, it will throw an error, you'd better to recreate the table in BigQuery and start a new replication task.


### PR DESCRIPTION
Currently tidb2dw read table schema from https://github.com/pingcap-inc/tidb2dw/blob/main/pkg/tidbsql/ddl.go#L115

```
SELECT COLUMN_NAME, COLUMN_DEFAULT, IS_NULLABLE, DATA_TYPE, 
CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, COLUMN_TYPE
FROM information_schema.columns
WHERE table_schema = "%s" AND table_name = "%s"
```

It can not recognize default string and default function as below:

```
mysql> create table t1 (a int primary key, b varchar(40) default 'uuid()');
mysql> create table t2 (a int primary key, b varchar(40) default uuid());
mysql> SELECT COLUMN_NAME, COLUMN_DEFAULT, IS_NULLABLE, DATA_TYPE,
    -> CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, COLUMN_TYPE
    -> FROM information_schema.columns
    -> WHERE table_schema = "test" AND table_name in ('t1', 't2');
+-------------+----------------+-------------+-----------+--------------------------+-------------------+---------------+--------------------+-------------+
| COLUMN_NAME | COLUMN_DEFAULT | IS_NULLABLE | DATA_TYPE | CHARACTER_MAXIMUM_LENGTH | NUMERIC_PRECISION | NUMERIC_SCALE | DATETIME_PRECISION | COLUMN_TYPE |
+-------------+----------------+-------------+-----------+--------------------------+-------------------+---------------+--------------------+-------------+
| a           | NULL           | NO          | int       |                     NULL |                11 |             0 |               NULL | int(11)     |
| b           | uuid()         | YES         | varchar   |                       40 |              NULL |          NULL |               NULL | varchar(40) |
| a           | NULL           | NO          | int       |                     NULL |                11 |             0 |               NULL | int(11)     |
| b           | uuid()         | YES         | varchar   |                       40 |              NULL |          NULL |               NULL | varchar(40) |
+-------------+----------------+-------------+-----------+--------------------------+-------------------+---------------+--------------------+-------------+
4 rows in set (0.01 sec)
```